### PR TITLE
automatic configuration and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+desire/
+parallel_master_v0.7
+.python-version
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -44,31 +44,18 @@ The ViSP preprocessing pipeline relies on tools in the
 [dkist tools package](https://docs.dkist.nso.edu/projects/python-tools/en/latest/installation.html),
 as supported by the DKIST data center. 
 
-Here is a list of additional packages to install for the ViSP pre-processing pipeline. These instructions
+Here is a list of additional packages to install for the ViSP pre-processing pipeline. 
 assume you have one of the anaconda variants installed for your package management.
 
-+ conda create -n dkist
++ conda create -n dkist python=3.11
 + conda activate dkist
-+ conda install -c conda-forge dkist
-+ conda install -c conda-forge numba
-+ conda install -c conda-forge mda-xdrlib
-+ conda install -c conda-forge scikit-learn
++ pip install .
+
+This will automatically set up and configure the necessary python packages, including numpy, pandas, dkist, etc. It will also automatically include https://github.com/dkistdc/RH/python/rhanalyze
 
 You may also want to install the jupyter package, to make plots, run tests.
 
 + conda install -c conda-forge jupyter
-
-The main set of routines *ViSP_inversion.py* depends on routines in the file ViSP_tools.py.
-You will have to make this file visble to python by including the path to it in your
-*PYTHONPATH* environment variable:
-
-+ export PYTHONPATH={$HOME}/your/ViSP_package/directory
-  
-Finally, the code needs to be able to read the solar disk-center atlas as implemented in the RH code.
-To indstall you will have to download the sub-directory *python/rhanalyze" from the [RH distribution
-on GitHub: ](https://github.com/han-uitenbroek/RH) and add that to your PYTHONPATH environment variable:
-
-+ export PYTHONPATH=${PYTHONPATH}:${HOME}/your/rhanalyze/directory
 
 ## 3.0 Inversions with DeSIRe
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,28 @@
+[metadata]
+name = ViSP-Inversion
+description = Preprocess ViSP L1 Data and Invert to L2
+long_description = file: README.md
+author = "NSO / AURA"
+author_email = "huitenbroek@nso.edu"
+license = BSD3
+url = https://github.com/DKISTDC/visp-inversion
+classifiers =
+  Programming Language :: Python
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.11
+
+[options]
+python_requires = >=3.11
+setup_requires = setuptools_scm
+packages = find:
+include_package_data = True
+install_requires =
+  numpy >= 2.2
+  dkist >= 1.13
+  pandas >= 2.2
+  numba >= 0.61
+  astropy >= 0.1
+  scipy >= 1.15
+  mda-xdrlib
+  scikit-learn
+  rhanalyze @ git+https://github.com/dkistdc/RH.git@1566439d65c0877942440757865f05402a3589cb#subdirectory=python

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(use_scm_version=True)


### PR DESCRIPTION
I added configuration files to automatically configure the project without installing or importing dependencies manually. This includes rhanalyze, although I forked https://github.com/han-uitenbroek/RH/ to dkistdc/RH. (See email - we have different options there)

Now a user can simply activate a virtualenv and run `pip install .` - From the updated README:

```
Here is a list of additional packages to install for the ViSP pre-processing pipeline. 
assume you have one of the anaconda variants installed for your package management.

+ conda create -n dkist python=3.11
+ conda activate dkist
+ pip install .

This will automatically set up and configure the necessary python packages, including numpy, pandas, dkist, etc. It will also automatically include https://github.com/dkistdc/RH/python/rhanalyze
```